### PR TITLE
Comment out :export-block use

### DIFF
--- a/ox-moinmoin.el
+++ b/ox-moinmoin.el
@@ -78,7 +78,7 @@
                      ;; (verbatim . org-moinmoin-verbatim)
                      ;; (verse-block . org-moinmoin-verse-block)
                      )
-  :export-block "MoinMoin"
+;;  :export-block "MoinMoin"
   :menu-entry
   '(?m "Export to MoinMoin"
        ((?M "As MoinMoin buffer" org-moinmoin-export-as-moinmoin)


### PR DESCRIPTION
:export-block is no longer used in the call to org-export-define-derived-backend in org-mode v9 and beyond, removing it makes this mode actually work again.